### PR TITLE
Call setFile for FilenameDatabase.

### DIFF
--- a/src/main/java/lib/PatPeter/SQLibrary/FilenameDatabase.java
+++ b/src/main/java/lib/PatPeter/SQLibrary/FilenameDatabase.java
@@ -29,8 +29,7 @@ public abstract class FilenameDatabase extends Database {
 			String directory,
 			String filename) {
 		super(log, prefix, dbms);
-		setDirectory(directory);
-		setFilename(filename);
+		setFile(directory, filename);
 	}
 	
 	public FilenameDatabase(Logger log, 
@@ -40,9 +39,7 @@ public abstract class FilenameDatabase extends Database {
 			String filename,
 			String extension) {
 		super(log, prefix, dbms);
-		setDirectory(directory);
-		setFilename(filename);
-		setExtension(extension);
+		setFile(directory, filename, extension);
 	}
 	
 	public String getDirectory() {


### PR DESCRIPTION
Ensures that the file variable is set. The original method calls are already included in the chain.
Fixes issue where using SQLite and file does not already exist, file was not created.

Signed-off-by: Vincent Deloso mitsugaru@gmail.com
