### PR TITLE
Use Maven resource filtering for common variables in YAML files.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,17 @@
 	</dependencies>
 
 	<build>
+		<resources>
+        	<resource>
+            	<includes>
+                	<include>config.yml</include>
+					<include>plugin.yml</include>
+					<include>properties.yml</include>
+                </includes>
+                <filtering>true</filtering>
+                <directory>${basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
-name: SQLibrary
-version: 7.1
+name: ${project.artifactId}
+version: ${project.version}
 description: A facade similar to Vault that abstracts the coder from the JDBC and each database driver's implementation.
 author: PatPeter
 main: lib.PatPeter.SQLibrary.SQLibrary

--- a/src/main/resources/properties.yml
+++ b/src/main/resources/properties.yml
@@ -1,5 +1,5 @@
-name: SQLibrary
-version: 7.1
+name: ${project.artifactId}
+version: ${project.version}
 description: A facade similar to Vault that abstracts the coder from the JDBC and each database driver's implementation.
 author: PatPeter
 platform: server


### PR DESCRIPTION
When you build the jar with Maven, it'll filter the variables in plugin.yml and properties.yml with what it has in the pom.xml. This way, you only need to modify the plugin version in one place, the POM.

If necessary, you should make sure the POM is formatted if / when you merge this in afterwards. For whatever reason my format for it isn't matching up correctly.
