### PR TITLE
Fix useless extension parameter in constructor

### DIFF
--- a/src/main/java/lib/PatPeter/SQLibrary/FilenameDatabase.java
+++ b/src/main/java/lib/PatPeter/SQLibrary/FilenameDatabase.java
@@ -75,6 +75,7 @@ public abstract class FilenameDatabase extends Database {
 			throw new DatabaseException("Extension cannot be null or empty.");
 		if (extension.charAt(0) != '.')
 			throw new DatabaseException("Extension must begin with a period");
+		this.extension = extension;
 	}
 	
 	public File getFile() {


### PR DESCRIPTION
This change fixes setExtension(String extension) so it actually sets the extension field.
As a result, the "extension" parameter will actually behave as intended in the FilenameDatabase(Logger log, String prefix, DBMS dbms, String directory, String filename, String extension) constructor.
In turn, any derived classes that call this constructor as well, such as SQLite and H2, will work as was intended.

On the down-side, any plugins that currently call this constructor with an extension other than ".db" will create a new database upon updating to a version of SQLibrary that includes this patch. Any server administrators affected by this should overwrite the newly created database with the old one (which would not be overwritten, as the extension will be different).
